### PR TITLE
Fix broken links due to moving markdown files from dp repo to this one

### DIFF
--- a/API_STANDARDS.md
+++ b/API_STANDARDS.md
@@ -16,7 +16,7 @@ More details of precise behaviour we expect including guidance on field names, t
 
 ## Our API Landscape
 
-Our [API training](../training/architecture/API.md) lays this out in more detail, but in order to allow each microservice API to focus on managing its data well some behaviour has been abstracted from the API services. This behaviour instead sits at the [API router](https://github.com/ONSdigital/dp-api-router).
+Our [API training](https://github.com/ONSdigital/dp/blob/main/training/architecture/API.md#api-architecture) lays this out in more detail, but in order to allow each microservice API to focus on managing its data well some behaviour has been abstracted from the API services. This behaviour instead sits at the [API router](https://github.com/ONSdigital/dp-api-router).
 
 Every request coming in on our api.ons.gov.uk domain must pass through our API router, which will perform a number of common checks and then determine which microservice to route traffic through to. When this API router is running internally, these checks include checking for relevant authentication headers and ensuring the request is audited for security reasons.
 
@@ -24,7 +24,7 @@ All API requests must travel through the API router, including app-to-app traffi
 
 We use feature flags to limit what behaviour is available on our public facing API microservices. Typically, only GET endpoints are exposed on public APIs, though user transaction services such as filter and flex data journeys are an exception to this.
 
-To add a new API microservice [follow our guide](../guides/NEW_API.md) to ensure the API router is updated correctly.
+To add a new API microservice [follow our guide](https://github.com/ONSdigital/dp/blob/main/guides/NEW_API.md#creating-a-new-api-microservice) to ensure the API router is updated correctly.
 
 ## API Structure and Syntax
 

--- a/ARCHITECTURE_STANDARDS.md
+++ b/ARCHITECTURE_STANDARDS.md
@@ -36,7 +36,7 @@ Innovate Responsibly™
 Single responsibilities - the systems and the teams
 ---------
 * [Loosely coupled microservices](https://microservices.io/microservices/2021/01/04/loosely-coupled-services.html)
-* All apps should be aligned to [12 Factor principles](../training/architecture/12_FACTOR_APP_PRINCIPLES.md)
+* All apps should be aligned to [12 Factor principles](https://github.com/ONSdigital/dp/blob/main/training/architecture/12_FACTOR_APP_PRINCIPLES.md#12-factor-app-principles)
 * An app must have sole ownership of its data
 * There must be a single source of truth for any data
 

--- a/DEPENDENCY_UPGRADING.md
+++ b/DEPENDENCY_UPGRADING.md
@@ -12,7 +12,7 @@ example, when go@1.x.1 is released then you should use it in your next pull requ
 
 If you notice any upgrades that are not covered by this policy (including major versions of DBs becoming available)
 raise them on the [20% board](https://trello.com/b/5G8rf9cm/20-time-backlog) for triage.
-Further reading on [contributing to 20% backlog](../training/culture-and-process/CONTRIBUTING_TO_20%_BACKLOG.md).
+Further reading on [contributing to 20% backlog](https://github.com/ONSdigital/dp/blob/main/training/culture-and-process/CONTRIBUTING_TO_20_TIME_BACKLOG.md#contributing-to-20-backlog-in-dp).
 
 We don’t update dependencies in legacy apps unless there is a security vulnerability (babbage, zebedee, train, brian,
 legacy florence).

--- a/DEV_STANDARDS.md
+++ b/DEV_STANDARDS.md
@@ -9,7 +9,7 @@ These are the Digital Publishing development standards.
   * App overview and 'Getting started' guide
   * Configuration info
   * Link to [LICENSE](../LICENSE.md) file
-  * Link to [contribution guidelines](../guides/CONTRIBUTING.md)
+  * Link to [contribution guidelines](https://github.com/ONSdigital/dp/blob/main/guides/CONTRIBUTING.md#contributing-to-digital-publishing-repos)
 * Change log
   * Don't list every commit
   * Include high-level features/bug fixes
@@ -29,7 +29,7 @@ These are the Digital Publishing development standards.
   * Include a Swagger spec file which documents any HTTP APIs
 * Pull requests / code review
 * 12-factor
-  * All code must be 12-factor compliant - see [https://12factor.net](https://12factor.net) and [our training module](../training/architecture/12_FACTOR_APP_PRINCIPLES.md)
+  * All code must be 12-factor compliant - see [https://12factor.net](https://12factor.net) and [our training module](https://github.com/ONSdigital/dp/blob/main/training/architecture/12_FACTOR_APP_PRINCIPLES.md#12-factor-app-principles)
 * [Sign commits using GPG](https://github.com/ONSdigital/dp-operations/blob/main/guides/gpg.md)
 * Use meaningful commit messages
 * Design patterns and best practices

--- a/DEV_STANDARDS.md
+++ b/DEV_STANDARDS.md
@@ -8,7 +8,7 @@ These are the Digital Publishing development standards.
 * README
   * App overview and 'Getting started' guide
   * Configuration info
-  * Link to [LICENSE](../LICENSE.md) file
+  * Link to [LICENSE](LICENSE.md) file
   * Link to [contribution guidelines](https://github.com/ONSdigital/dp/blob/main/guides/CONTRIBUTING.md#contributing-to-digital-publishing-repos)
 * Change log
   * Don't list every commit
@@ -82,4 +82,4 @@ See also [Logging standards](LOGGING_STANDARDS.md).
   * `fix/fix-name` branches
   * `hotfix/hotfix-name` branches
   * Use GPG signed annotated release tags
-* [Pull request templates](../.github/PULL_REQUEST_TEMPLATE.md)
+* [Pull request templates](.github/PULL_REQUEST_TEMPLATE.md)


### PR DESCRIPTION
### What

See title - I focussed on ones which would break from the move from dp to dp-standards; if there are broken links which were broken in the dp repo I wouldn't have spotted these - feel free to test all links

### How to review

Check markdown files do not include any broken links

### Who can review

Anyone
