### PR TITLE
Add a repo licensing standard

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright (c) 2022 Office for National Statistics
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSING_STANDARD.md
+++ b/LICENSING_STANDARD.md
@@ -1,0 +1,69 @@
+# Code Licensing
+
+This standard outlines the requirements for appropriate licensing for open source code repositories (e.g. public git repositories) maintained by Dissemination.
+
+This standard is broadly similar to the [GDS Way Licensing guidance](https://gds-way.digital.cabinet-office.gov.uk/manuals/licensing.html#licensing) and follows the [UK Government Licensing Framework](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/).
+
+## Repositories MUST Include an Open Source Licence
+
+All public git repositories MUST be covered by appropriate licensing as specified by a LICENCE file(s) containing the licence text(s) in full and a Licence section in the README with a link(s) to the LICENCE file(s) clearly stating what licence(s) apply and, where there are multiple, what is covered by each licence. See [Readme notice notice](#readme-notice-wording) for an example.
+
+The appropriate licence will depend on the contents of the repo:
+
+* Code: All source code repositories MUST be published under the MIT License as the default standard (see exception noted below)
+* Documentation: All documentation only repositories MUST be published under the Open Government Licence v3 (OGL3)
+* Mixed Code and Documentation (e.g. code that generates static documentation sites): All repos containing a mix of code and documentation, where the documentation is not documentation about the code in the same repo, MUST be published under the MIT License for the code and under the OGL3 licence for the documentation
+* Mixed Code and Open Data: All repos containing a mix of code and open data (this excludes "fake" data for test purposes) MUST be published under the MIT License for the code and under the OGL3 licence for the data by default (see exception noted below)
+* Mixed Code and Government Assets: All repos containing a mix of code and government assets (e.g. logos) MUST be published under the MIT License for the code and under the OGL3 licence for the assets
+
+MIT Exception: Where a repository incorporates third-party components with restrictive "copyleft" or specific attribution requirements (e.g., GPL, Apache 2.0, or BSD), an alternative Open Source Initiative (OSI) approved licence MUST be applied to the code to ensure legal compatibility while maintaining maximum re-use potential.
+
+OGL3 Exception: Where a repository incorporates data from third-parties with restrictive "copyleft" or specific attribution requirements, this MUST be noted with the original or an alternative legally compatible licence included.
+
+## Repositories MUST State Crown Copyright
+
+All work created by civil servants and contractors for the ONS is Crown Copyright.
+
+All repositories MUST include a copyright notice that reads:
+
+```text
+Copyright (c) {YEAR} Crown Copyright (Office for National Statistics)
+```
+
+The `{YEAR}` MUST be the first year that the code was published (i.e. made public).
+
+The copyright notice MUST appear in the licence file.
+
+It is RECOMMENDED to include the copyright notice in the readme.
+
+It is NOT RECOMMENDED to extend the copyright date each year using a range. The crown copyright for published literary work, which includes code, is 50 years from the end of copyright year. The functional repository lifespan is expected to be significantly shorter so therefore extending the licence range by a year is wasted effort.
+
+### Example copyright notice
+
+The following is an example copyright notice as it must appear in the licence file:
+
+```text
+Copyright (c) 2025 Crown Copyright (Office for National Statistics)
+```
+
+## Readme notice wording
+
+The readme MUST state the the repo is under Crown Copyright, clearly state the licensing and link to the appropriate licence files.
+
+The following is the RECOMMENDED default wording:
+
+```markdown
+Copyright (c) {{YEAR}} [Crown Copyright](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/) (Office for National Statistics)
+
+Unless stated otherwise, the codebase is released under the [MIT License](./LICENCE.md).
+```
+
+Repositories containing a mix of code and other categories of files will need to modify this default wording to make it clear where the MIT License does not apply. For example, the following might be used for a documentation site like the Developer Hub:
+
+```markdown
+Copyright (c) {{YEAR}} [Crown Copyright](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/) (Office for National Statistics)
+
+Unless stated otherwise, the codebase is released under the [MIT License](./LICENCE.md). This covers both the codebase and any sample code in the documentation.
+
+The documentation site content is released under the [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+```

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ To contribute to the standards, whether that is to create new standards or chang
 
 * [API Standards](./API_STANDARDS.md)
 * [Architecture Principles](./ARCHITECTURE_PRINCIPLES.md)
+* [Commit standards](./COMMIT_STANDARDS.md)
 * [Dependency Upgrading](./DEPENDENCY_UPGRADING.md)
 * [Development Standards](./DEV_STANDARDS.md)
 * [Healthcheck Specification](./HEALTH_CHECK_SPECIFICATION.md)
-* [Registering Health Checkers](./REGISTERING_HEALTH_CHECKERS.md)
+* [Licensing Standard](./LICENSING_STANDARD.md)
+* [Linting Standard](./LICENSE.md)
 * [Logging Standards](./LOGGING_STANDARDS.md)
+* [Registering Health Checkers](./REGISTERING_HEALTH_CHECKERS.md)
 * [Repository Standards](./REPOSITORY_STANDARDS.md)
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ To contribute to the standards, whether that is to create new standards or chang
 * [Development Standards](./DEV_STANDARDS.md)
 * [Healthcheck Specification](./HEALTH_CHECK_SPECIFICATION.md)
 * [Licensing Standard](./LICENSING_STANDARD.md)
-* [Linting Standard](./LICENSE.md)
+* [Linting Standard](./LINTING.md)
 * [Logging Standards](./LOGGING_STANDARDS.md)
 * [Registering Health Checkers](./REGISTERING_HEALTH_CHECKERS.md)
 * [Repository Standards](./REPOSITORY_STANDARDS.md)
 
 ## Licence
 
-Copyright © 2022, Office for National Statistics (<https://www.ons.gov.uk>)
+Copyright (c) 2019 [Crown Copyright](http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/) (Office for National Statistics)
 
-Released under MIT license, see [LICENSE](LICENSE.md) for details.
+Unless stated otherwise, the documentation in this repo are released under the [Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).


### PR DESCRIPTION
### What

Add a standard to clarify expectations for repo copyright notices and licence information.

This standard is based on the GDS Way licensing guidance, being specific about how we apply this guidance in Dissemination.

Update the licence and copyright to comply with the new licensing standard.

### How to review

Ensure the standard's wording is clear
Ensure that the proposed wording for the readme is clear

### Who can review

!me
