### PR TITLE
docs(logging): add classification and spec_version fields to spec

### DIFF
--- a/LOGGING_STANDARDS.md
+++ b/LOGGING_STANDARDS.md
@@ -2,7 +2,7 @@
 
 ## Libraries
 
-We have libraries the following libaries which match the logging standards defined below:
+The following libraries implement the logging standards defined below:
 
 * Go - [github.com/ONSdigital/log.go](https://github.com/ONSdigital/log.go)
 * Java - [com.github.onsdigital.logging](https://github.com/ONSdigital/dp-logging)
@@ -61,25 +61,55 @@ Although "human readable" formatting is useful for local development, all apps d
 
 The following are the only top level fields. If you have app specific details you wish to add, it is likely that they should be added under `data` rather than creating a new field.
 
-| Field name   | Required | Type                           | Example                      | Description                                                             |
-|--------------|----------|--------------------------------|------------------------------|-------------------------------------------------------------------------|
-| `auth`       | No       | [`auth`](#auth-event-data)     |                              | [Authentication event data](#auth-event-data)                           |
-| `created_at` | Yes      | `datetime`[^1]                 | `"2019-01-21T16:19:12.356Z"` | Date and time of the log event (ISO8601 extended date and time string)  |
-| `data`       | No       | `object`[^3]                   |                              | [Arbitrary key-value pairs](#arbitrary-data-fields)                     |
-| `errors`     | No       | [`[]error`](#error-event-data) |                              | [Error event data](#error-event-data)                                   |
-| `event`      | Yes      | `string`                       | `"connecting to mongodb"`    | [The event being logged](#effective-event-types)                        |
-| `http`       | No       | [`http`](#http-event-data)     |                              | [HTTP event data](#http-event-data)                                     |
-| `namespace`  | Yes      | `string`                       | `"dp-frontend-router"`       | Service name or other identifier                                        |
-| `raw`        | No       | `string`                       |                              | [Log message captured from a third party library](#third-party-logs)    |
-| `severity`   | Yes      | `int8`                         | `2`                          | [The event severity level code](#severity-levels)                       |
-| `span_id`    | No       | `string`                       |                              | [Span ID from OpenCensus](https://opencensus.io/tracing/span/spanid/)   |
-| `trace_id`   | No[^2]   | `string`                       |                              | [Trace ID from OpenCensus](https://opencensus.io/tracing/span/traceid/) |
+| Field name       | Required | Type                           | Example                      | Description                                                                               |
+|------------------|----------|--------------------------------|------------------------------|-------------------------------------------------------------------------------------------|
+| `auth`           | No       | [`auth`](#auth-event-data)     |                              | [Authentication event data](#auth-event-data)                                             |
+| `classification` | No       | `string`                       | `"protective_monitoring"`    | [Log classification for platform routing and special handling](#classification)           |
+| `created_at`     | Yes      | `datetime`[^1]                 | `"2019-01-21T16:19:12.356Z"` | Date and time of the log event (ISO8601 extended date and time string)                    |
+| `data`           | No       | `object`[^3]                   |                              | [Arbitrary key-value pairs](#arbitrary-data-fields)                                       |
+| `errors`         | No       | [`[]error`](#error-event-data) |                              | [Error event data](#error-event-data)                                                     |
+| `event`          | Yes      | `string`                       | `"connecting to mongodb"`    | [The event being logged](#effective-event-types)                                          |
+| `http`           | No       | [`http`](#http-event-data)     |                              | [HTTP event data](#http-event-data)                                                       |
+| `namespace`      | Yes      | `string`                       | `"dp-frontend-router"`       | Service name or other identifier                                                          |
+| `raw`            | No       | `string`                       |                              | [Log message captured from a third party library](#third-party-logs)                      |
+| `severity`       | Yes      | `int8`                         | `2`                          | [The event severity level code](#severity-levels)                                         |
+| `spec_version`   | No       | `string`                       | `"v1"`                       | [Major version of this logging specification used by the emitting library](#spec-version) |
+| `span_id`        | No       | `string`                       |                              | [Span ID from OpenCensus](https://opencensus.io/tracing/span/spanid/)                     |
+| `trace_id`       | No[^2]   | `string`                       |                              | [Trace ID from OpenCensus](https://opencensus.io/tracing/span/traceid/)                   |
 
 [^1]: All dates must be UTC and in ISO8601 extended date time format with at least millisecond precision: `yyyy-MM-dd'T'HH:mm:ss.SSSZZ` (e.g. `2019-01-21T16:19:12.356Z`).
 
 [^2]: Not mandatory, but must be included for all events created during the handling of a request.
 
 [^3]: The event-specific details in `data` are input as an object/map in code, but are stored as a text string by the centralised logging service to allow additional detail to be added to an event without needing to worry about key name collision.  These details can still be searched using a general text search on the `data` field.
+
+#### Spec version
+
+The `spec_version` field is an optional identifier for the major version of this logging specification that the emitting library claims conformance with.
+
+If `spec_version` is not provided, it will be treated as `v1`.
+
+The logging libraries should set `spec_version` automatically on every emitted log line. Services should not override it in normal operation.
+
+#### Classification
+
+The `classification` field is an optional, single value used to mark logs that require special platform handling.
+
+This is primarily intended for platform routing (for example sending protective monitoring logs to Sentinel). It is not a severity indicator and **must not** be used as a substitute for `severity`.
+
+If `classification` is not provided, the event is treated as unclassified and normal routing applies.
+
+Allowed values (controlled vocabulary):
+
+| Value                   | Meaning                                                                    |
+|-------------------------|----------------------------------------------------------------------------|
+| `protective_monitoring` | Security relevant events intended for protective monitoring / SIEM routing |
+
+Rules:
+
+* values must be lowercase and snake_case
+* services must not invent new values; new values must be added to this specification
+* values must describe the category/intent, not the action to be taken by the platform
 
 #### HTTP event data
 
@@ -183,11 +213,43 @@ For example:
 ```json
 {
   "created_at" : "2019-02-01T13:45:24.157Z",
-  "namespace" : "my-app",
+  "namespace" : "dis-example-service",
+  "spec_version" : "v1",
   "trace_id": "1105cb0c04f86a4b6a1abaf74246b87f",
   "severity" : 3,
   "event": "third party log",
   "raw" : "Started ServerConnector@7f4fedd{HTTP/1.1,[http/1.1]}{0.0.0.0:4567}"
+}
+```
+
+### Routing examples
+
+Normal log (no special routing):
+
+```json
+{
+  "created_at": "2026-01-01T09:15:30.123Z",
+  "namespace": "dis-example-service",
+  "spec_version": "v1",
+  "severity": 3,
+  "event": "starting service"
+}
+```
+
+Protective monitoring log (eligible for routing to Sentinel):
+
+```json
+{
+  "created_at": "2026-01-01T09:15:30.123Z",
+  "namespace": "dis-example-service",
+  "spec_version": "v1",
+  "severity": 2,
+  "event": "permission denied",
+  "classification": "protective_monitoring",
+  "data": {
+    "action": "read_dataset",
+    "reason": "missing_permission"
+  }
 }
 ```
 

--- a/LOGGING_STANDARDS.md
+++ b/LOGGING_STANDARDS.md
@@ -64,7 +64,7 @@ The following are the only top level fields. If you have app specific details yo
 | Field name       | Required | Type                           | Example                      | Description                                                                               |
 |------------------|----------|--------------------------------|------------------------------|-------------------------------------------------------------------------------------------|
 | `auth`           | No       | [`auth`](#auth-event-data)     |                              | [Authentication event data](#auth-event-data)                                             |
-| `classification` | No       | `string`                       | `"protective_monitoring"`    | [Log classification for platform routing and special handling](#classification)           |
+| `classification` | No       | `string`                       | `"PROTECTIVE_MONITORING"`    | [Log classification for platform routing and special handling](#classification)           |
 | `created_at`     | Yes      | `datetime`[^1]                 | `"2019-01-21T16:19:12.356Z"` | Date and time of the log event (ISO8601 extended date and time string)                    |
 | `data`           | No       | `object`[^3]                   |                              | [Arbitrary key-value pairs](#arbitrary-data-fields)                                       |
 | `errors`         | No       | [`[]error`](#error-event-data) |                              | [Error event data](#error-event-data)                                                     |
@@ -103,7 +103,7 @@ Allowed values (controlled vocabulary):
 
 | Value                   | Meaning                                                                    |
 |-------------------------|----------------------------------------------------------------------------|
-| `protective_monitoring` | Security relevant events intended for protective monitoring / SIEM routing |
+| `PROTECTIVE_MONITORING` | Security relevant events intended for protective monitoring / SIEM routing |
 
 Rules:
 
@@ -245,7 +245,7 @@ Protective monitoring log (eligible for routing to Sentinel):
   "spec_version": "v1",
   "severity": 2,
   "event": "permission denied",
-  "classification": "protective_monitoring",
+  "classification": "PROTECTIVE_MONITORING",
   "data": {
     "action": "read_dataset",
     "reason": "missing_permission"


### PR DESCRIPTION
### What

This PR introduces a small, backwards compatible update to the logging standard to help with log routing and versioning in the future.

It adds a `spec_version` field (like "v1", "v2", etc.) so libraries can show which major version of the spec they follow. This helps us prepare for future changes, making it easier to introduce breaking changes later while letting the platform and libraries handle different versions correctly.

It also adds a `classification` field to help route certain logs that need special platform handling, like protective monitoring events (such as 401 or 403 errors).

<details>

<summary><strong>Rationale and other options</strong></summary>

This change is backwards compatible, so existing logs will still work. Services can add the new fields gradually through updates to the shared logging libraries.

For the platform team, when `classification` appears, pipelines can start routing or handling those logs differently, while older logs will still follow the default process.

#### Why we’re doing this

We need a clear and consistent way for the platform to identify protective monitoring logs so they can be sent to Sentinel.

We also want to avoid putting routing rules into event strings or adding one-off flags that do not scale. Having a single, well-defined `classification` field lets us add new categories later without changing the schema each time.

Also, until now, we have not had a clear way to identify schema versions or to make breaking changes gracefully. The new `spec_version` field provides that information without causing any immediate or breaking changes to services.

#### How this is expected to be used

Services can set `classification` to "PROTECTIVE_MONITORING" for events that must be treated as protective monitoring. The platform team can then route those logs to Sentinel by matching on that value.

The logging libraries are expected to set the `spec_version` field automatically. In most cases, services will not need to change it themselves.

If either field is missing, the default behaviour will apply. Logs will be routed as usual, and the spec version will be treated as unknown or legacy.

#### Other options considered

A few alternative approaches have been considered:

Using a simple boolean flag like `protective: true` would have been quick, but it does not scale well. If we add more special categories, we would end up with several top-level flags and a messy schema.

We also considered introducing a new severity or log level, but that mixes up two different concerns: how severe an event is, and where it should be routed. It would also require coordinated changes across libraries and consumers.

An array of `tags/classifications` was another option. While flexible, it adds routing complexity that needs to be spiked, which we cannot currently accommodate.

For now, this approach keeps the change small and easy to adopt.

</details>


Follow up actions needed:
- Update the shared logging libraries to support this change.
- Add log routing support for protective monitoring events


### How to review

- Ensure the changes make sense and are appropriate.
- Read the "Rationale and other options" section and consider whether there is a more suitable option that should be taken into account.

### Who can review

Anyone! + Needs @ONSdigital/dissemination-tech-leads 