### PR TITLE
docs(logging): correct classification rule to require uppercase values

### DIFF
--- a/LOGGING_STANDARDS.md
+++ b/LOGGING_STANDARDS.md
@@ -109,7 +109,7 @@ Allowed values (controlled vocabulary):
 
 Rules:
 
-* values must be lowercase and snake_case
+* values must be uppercase and snake case (e.g. `EXAMPLE_VALUE`)
 * services must not invent new values; new values must be added to this specification
 * values must describe the category/intent, not the action to be taken by the platform
 

--- a/LOGGING_STANDARDS.md
+++ b/LOGGING_STANDARDS.md
@@ -109,7 +109,7 @@ Allowed values (controlled vocabulary):
 
 Rules:
 
-* values must be uppercase and snake case (e.g. `EXAMPLE_VALUE`)
+* values must be uppercase letters separated by underscores (e.g. `EXAMPLE_VALUE`)
 * services must not invent new values; new values must be added to this specification
 * values must describe the category/intent, not the action to be taken by the platform
 


### PR DESCRIPTION
### What

The `classification` section already defines controlled values in `UPPERCASE_SNAKE_CASE` (for example `PROTECTIVE_MONITORING`), but the rule previously stated that values must be lowercase. This PR corrects the rule to use uppercase.

### How to review

Ensure the change makes sense

### Who can review

!me